### PR TITLE
feat: Add support for AndroidX

### DIFF
--- a/android/src/main/java/com/rajivshah/safetynet/RNGoogleSafetyNetModule.java
+++ b/android/src/main/java/com/rajivshah/safetynet/RNGoogleSafetyNetModule.java
@@ -1,7 +1,7 @@
 
 package com.rajivshah.safetynet;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.app.Activity;
 import android.util.Log;
 import android.util.Base64;


### PR DESCRIPTION
When building for release, the previous implementation throws an error related to AndroidX support.

This is because `android.support.annotation.NonNull` namespace does not exist anymore and has been replaced by `androidx.annotation.NonNull`.

![image](https://user-images.githubusercontent.com/1884255/154453525-c455dd71-8bc2-480c-8374-167b26937050.png)
