### PR TITLE
feat: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cozy-react-native-google-safetynet",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "React Native implementation for Google's SafetyNet API",
     "author": "Rajiv Shah <rajivshah1@icloud.com>",
     "license": "MIT",


### PR DESCRIPTION
V1.0.1 has been published to NPM from this branch https://www.npmjs.com/package/cozy-react-native-google-safetynet